### PR TITLE
Update props.js

### DIFF
--- a/src/uni_modules/uview-plus/components/u-slider/props.js
+++ b/src/uni_modules/uview-plus/components/u-slider/props.js
@@ -29,6 +29,7 @@ export default {
 			type: [String, Number],
 			default: defprops.slider.value
 		},
+		// #endif
         // 滑块右侧已选择部分的背景色
         activeColor: {
             type: String,


### PR DESCRIPTION
u-slider组件的props.js文件少了一个#endif，导致使用标错